### PR TITLE
Allow a "bootstrap" file when testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
 
     registerActions() {
 
-
       S.addAction(this._createAction.bind(this), {
         handler:       'customAction',
         description:   'Create mocha test for function',
@@ -81,8 +80,6 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
           }
         ]
       });
-
-      
       
       return BbPromise.resolve();
     }


### PR DESCRIPTION
This is my first pull request to anything Serverless-related, so apologies if there are any conventions I haven't adhered to.

I need to run a bootstrap file before my tests - primarily to override some modules my code requires, in order to stub out database calls. I've added an options object to `custom` in `s-project.json` like so:

```
{
    "custom": {
        "serverless-mocha-plugin": {
            "bootstrap": "test-bootstrap.js"
        }
  }
}
```

This requires that file as part of the mocha test startup.
