### PR TITLE
Add IS_LOCAL env variable for to make sls invoke local

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ NOTE: Live running does not currently work. Waiting for serverless 1.0 to finali
 
 ### Running tests
 
-Tests can be run directly using the "invoke test" command. This also initializes the environment variables based on your serverless.yml file and the SERVERLESS_TEST_ROOT variable that defines the root for the code to be tested.
+Tests can be run directly using the "invoke test" command. This also initializes the environment variables based on your serverless.yml file and the SERVERLESS_TEST_ROOT variable that defines the root for the code to be tested. If you're running the tests locally (rather than on live Lambdas, as described below), it will also set the `IS_LOCAL` to `'true'` to match the behavior of [`sls invoke local`](https://serverless.com/framework/docs/providers/aws/cli-reference/invoke-local#environment).
 
 ```
 sls invoke test [--stage stage] [--region region] [-f function1] [-f function2] [...]

--- a/index.js
+++ b/index.js
@@ -273,6 +273,9 @@ class mochaPlugin {
               process.env['SERVERLESS_MOCHA_PLUGIN_REGION'] = region || inited.provider.region;
               process.env['SERVERLESS_MOCHA_PLUGIN_SERVICE'] = inited.service;
               process.env['SERVERLESS_MOCHA_PLUGIN_STAGE'] = stage || inited.provider.stage;
+            } else {
+              // Set the `IS_LOCAL` env variable to match the `sls invoke local` environment.
+              process.env['IS_LOCAL'] = true;
             }
             /* eslint-enable dot-notation */
 


### PR DESCRIPTION
Adds the `IS_LOCAL` environment variable when running tests locally (_not_ live) to match the behavior from `sls invoke local`. 

Impetus for this change was [this tweet](https://twitter.com/jeremy_daly/status/922497709726105601).

My guess is that this won't break many people's workflows, but I'm not positive on that. I'd prefer to have it enabled by default but could put it behind a flag in the config if that's preferred. 