### PR TITLE
Typo about offline serverless command example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ if [ -f .offline.pid ]; then
     exit 1
 fi
 
-serverless offline start 2>1 > $TMPFILE &
+serverless offline 2>1 > $TMPFILE &
 PID=$!
 echo $PID > .offline.pid
 


### PR DESCRIPTION
The previous version doesn't work. It remains in some "weird" infinite loop. This new version works perfectly.

Some additional information regarding my machine/environment:
* Node v9.11.1
* NPM 5.8.0
* Serverless 1.27.1
* Serverless Offline plugin 3.20.3
* Serverless Mocha plugin 1.8.0

And right, the famous `uname -a` :joy: :
```
Linux Ivalice 4.13.0-39-generic #44~16.04.1-Ubuntu SMP Thu Apr 5 16:43:55 UTC 2018 i686 i686 i686 GNU/Linux
```

Thanks in advance, :pray: .