### PR TITLE
Ability to configure mocha babel compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ Sample stopOffline.sh
 kill `cat .offline.pid`
 rm .offline.pid
 ```
+
+### Usage with [babel register](https://babeljs.io/docs/en/babel-register)
+
+If you use mocha with [babel compiler](https://github.com/mochajs/mocha/wiki/compilers-deprecation) e.g. `sls invoke test --compilers js:@babel/register` \
+Babel configuration can be determined with the custom `babelOptions` configuration in serverless.yml
+
+```
+custom:
+  serverless-mocha-plugin:
+    babelOptions:
+      presets: [["@babel/env", { "targets": { "node": "8.10" }, "shippedProposals": true, "useBuiltIns": "usage" }]]
+      plugins:
+        - ["@babel/plugin-transform-runtime"]
+```
 ## Release History (1.x)
 
 * 2018/12/15 - v1.9.1 - fix to work with serverless 1.33 and later

--- a/index.js
+++ b/index.js
@@ -282,7 +282,14 @@ class mochaPlugin {
               if (mod[0] === '.') {
                 mod = path.join(process.cwd(), mod);
               }
-              require(mod); // eslint-disable-line global-require
+
+              const babelModules = ['babel-register', '@babel/register'];
+              const babelConf = ((this.serverless.service.custom || {})['serverless-mocha-plugin'] || {}).babelOptions; // eslint-disable-line max-len
+              if (babelModules.includes(mod) && babelConf) {
+                require(mod)(babelConf); // eslint-disable-line global-require
+              } else {
+                require(mod); // eslint-disable-line global-require
+              }
               extensions.push(ext);
             });
           }


### PR DESCRIPTION
Ability to configure [babel](https://babeljs.io/docs/en/babel-register) [mocha compiler](https://github.com/mochajs/mocha/wiki/compilers-deprecation) 

Example:
```
custom:
  serverless-mocha-plugin:
    babelOptions:
      presets: [["@babel/env", { "targets": { "node": "8.10" }, "shippedProposals": true, "useBuiltIns": "usage" }]]
      plugins:
        - ["@babel/plugin-transform-runtime"]
```

PS: Similar to [serverless-offline](https://github.com/dherault/serverless-offline/tree/v3.32.1#usage-with-babel)