### PR TITLE
Fix process exit code on test fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,6 +288,7 @@ class mochaPlugin {
           }
           return null;
         }, error => myModule.serverless.cli.log(error));
+        let runnerFailures = 0;
         mocha.run((failures) => {
           process.on('exit', () => {
             myModule.runScripts('postTestCommands')
@@ -302,10 +303,12 @@ class mochaPlugin {
           } else {
             utils.setEnv(myModule.serverless);
           }
+        }).on('fail', () => {
+          runnerFailures++;
         }).on('end', () => {
           resolve();
           if (myModule.options.exit) {
-            process.exit();
+            process.exit(runnerFailures > 0 ? 1 : 0);
           }
         });
         return null;


### PR DESCRIPTION
In case you use --exit option, process will exit with default exit code and you will never know about any test failures.

PS: Duplicate of https://github.com/nordcloud/serverless-mocha-plugin/pull/103