### PR TITLE
Added missing runtime option

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const validFunctionRuntimes = [
   'aws-nodejs4.3',
   'aws-nodejs6.10',
   'aws-nodejs8.10',
+  'aws-nodejs10.x'
 ];
 
 const humanReadableFunctionRuntimes = `${validFunctionRuntimes


### PR DESCRIPTION
Serverless now support node 10.x runtime available in Lambda