### PR TITLE
Check runtime var before use it

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,8 +182,9 @@ class mochaPlugin {
       // Verify that the service runtime matches with the current runtime
       let { runtime } = inited.provider;
       // Fix the real version for node10
-      if (runtime)
+      if (runtime) {
         runtime = runtime.replace('.x', '');
+      }
 
       let nodeVersion;
       if (typeof process.versions === 'object') {

--- a/index.js
+++ b/index.js
@@ -182,7 +182,8 @@ class mochaPlugin {
       // Verify that the service runtime matches with the current runtime
       let { runtime } = inited.provider;
       // Fix the real version for node10
-      runtime = runtime.replace('.x', '');
+      if (runtime)
+        runtime = runtime.replace('.x', '');
 
       let nodeVersion;
       if (typeof process.versions === 'object') {


### PR DESCRIPTION
To avoid "Cannot read property 'replace' of undefined" error if provider dont have Node version.