### PR TITLE
Fix #121 updated startOffline.sh example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ serverless offline 2>1 > $TMPFILE &
 PID=$!
 echo $PID > .offline.pid
 
-while ! grep "Offline listening" $TMPFILE
+while ! grep "server ready" $TMPFILE
 do sleep 1; done
 
 rm $TMPFILE
 ```
+
+**Note:** The example relies on the output of the `serverless offline` command. If the start script is not working for you, replace `server ready` with the string `serverless offline` prints as soon as the server is ready and listening.
 
 Sample stopOffline.sh
 ```

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ do sleep 1; done
 rm $TMPFILE
 ```
 
-**Note:** The example relies on the output of the `serverless offline` command. If the start script is not working for you, replace `server ready` with the string `serverless offline` prints as soon as the server is ready and listening.
+**Note:** The example relies on the output of the `serverless offline` command. If the start script is not working for you, replace `"server ready"` with the string `serverless offline` prints as soon as the server is ready and listening.
 
 Sample stopOffline.sh
 ```


### PR DESCRIPTION
Small change to the readme.md.

As serverless offline changed the output of the `serverless offline` command the `startOffline.sh` script gets stuck depending on the used serverless offline version.

I adjusted the script for the next serverless offline version and added a note how do adjust the script, in case an other serverless offline version is used.