### PR TITLE
Fixed typo in sample startOffline

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ if [ -f .offline.pid ]; then
     exit 1
 fi
 
-serverless offline 2>1 > $TMPFILE &
+serverless offline 2>&1 > $TMPFILE &
 PID=$!
 echo $PID > .offline.pid
 


### PR DESCRIPTION
The original sample will create a file named 1 instead of piping stderr to stdout.