### PR TITLE
Documentation: Update Framework version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 A Serverless Plugin for the [Serverless Framework](http://www.serverless.com), which
 adds support for test driven development using [mocha](https://mochajs.org/)
 
-**THIS PLUGIN REQUIRES SERVERLESS V1!**
-
 More familiar with Jest? Use [serverless-jest-plugin](https://github.com/sc5/serverless-jest-plugin).
 
 ## Introduction


### PR DESCRIPTION
This plugin works with v2, and is likely to work with v3.

I believe this version info is from v0.5 to v1 migration days, and can safely be removed now